### PR TITLE
Fix/header

### DIFF
--- a/.github/workflows/set-backend.yml
+++ b/.github/workflows/set-backend.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "backend/**"
 
 jobs:
   sync-backend:

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,7 +3,11 @@ import LandingSection from "@/components/shared/Landing";
 export default function About() {
   return (
     <>
-      <LandingSection backgroundPath="/images/background-image-2.jpg" />
+      <LandingSection
+        backgroundPath="/images/background-image-2.jpg"
+        landingText="From humble beginnings to trusted experts, here's our story."
+        headlineText="Get to Know Us"
+      />
       This is the about page
     </>
   );

--- a/src/app/our-work/page.tsx
+++ b/src/app/our-work/page.tsx
@@ -31,7 +31,10 @@ export default function OurWork() {
   // }, [category]);
   return (
     <>
-      <LandingSection backgroundPath="/images/background-image-1.jpg" />
+      <LandingSection
+        backgroundPath="/images/background-image-1.jpg"
+        landingText="Crafting Beauty, One Project at a Time"
+      />
       <Gallery category="Exterior" imageProps={galleryImages.images.exterior} />
       <Gallery category="Interior" imageProps={galleryImages.images.interior} />
     </>

--- a/src/app/our-work/page.tsx
+++ b/src/app/our-work/page.tsx
@@ -32,8 +32,9 @@ export default function OurWork() {
   return (
     <>
       <LandingSection
-        backgroundPath="/images/background-image-1.jpg"
-        landingText="Crafting Beauty, One Project at a Time"
+        backgroundPath="/images/background-image-2.jpg"
+        headlineText="Bringing Color to Life"
+        landingText="Step into our gallery and see how we bring color to life. From vibrant exteriors to elegant interiors, our work is a celebration of color and design."
       />
       <Gallery category="Exterior" imageProps={galleryImages.images.exterior} />
       <Gallery category="Interior" imageProps={galleryImages.images.interior} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,11 @@ import ReviewCarousel from "@/components/home/ReviewCarousel";
 export default function Home() {
   return (
     <div className="flex flex-col gap-20">
-      <LandingSection backgroundPath="/images/background-image-1.jpg" />
+      <LandingSection
+        backgroundPath="/images/background-image-1.jpg"
+        landingText="Transforming Homes & Businesses Throughout the Bay Area"
+      />
+
       <ServiceAreasSection />
       <OurServicesSection />
       <ReviewCarousel />

--- a/src/components/header/HeaderButtons.tsx
+++ b/src/components/header/HeaderButtons.tsx
@@ -1,4 +1,5 @@
 import { navItems, scrollToSection } from "./utils";
+import { usePathname, useRouter } from "next/navigation";
 import ServicesButtons from "../home/services/ServicesButtons";
 import Link from "next/link";
 
@@ -14,6 +15,25 @@ export function HeaderMobileButtons({
 }: {
   toggleMenu: () => void;
 }) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Function to handle button click (redirect to section on home page or another page)
+  function handleHomeClick(
+    e: React.MouseEvent<HTMLButtonElement>,
+    itemId: string
+  ) {
+    e.preventDefault();
+    if (pathname === "/") {
+      scrollToSection(itemId);
+    } else {
+      router.push(`/`);
+      // Set timeout to scroll to section after the page has changed
+      setTimeout(() => {
+        scrollToSection(itemId);
+      }, 300);
+    }
+  }
   return (
     <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
       {navItems.map((item) => {
@@ -30,8 +50,9 @@ export function HeaderMobileButtons({
         return item.homePage ? (
           <button
             key={item.id}
-            onClick={() => {
-              scrollToSection(item.id);
+            onClick={(e) => {
+              // scrollToSection(item.id);
+              handleHomeClick(e, item.id);
               toggleMenu();
             }}
             aria-label={item.ariaLabel}
@@ -59,6 +80,26 @@ export function HeaderMobileButtons({
 }
 
 export function HeaderDesktopButtons() {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Function to handle button click (redirect to section on home page or another page)
+  function handleHomeClick(
+    e: React.MouseEvent<HTMLButtonElement>,
+    itemId: string
+  ) {
+    e.preventDefault();
+    if (pathname === "/") {
+      scrollToSection(itemId);
+    } else {
+      router.push(`/`);
+      // Set timeout to scroll to section after the page has changed
+      setTimeout(() => {
+        scrollToSection(itemId);
+      }, 300);
+    }
+  }
+
   return (
     <div className="flex items-center space-x-8">
       {/* Check if button or link takes user to a section on the home page or to another page */}
@@ -70,7 +111,7 @@ export function HeaderDesktopButtons() {
         return item.homePage ? (
           <button
             key={item.id}
-            onClick={() => scrollToSection(item.id)}
+            onClick={(e) => handleHomeClick(e, item.id)}
             aria-label={item.ariaLabel}
             className={baseDesktopClasses}
           >

--- a/src/components/home/LeafLetMap.tsx
+++ b/src/components/home/LeafLetMap.tsx
@@ -4,14 +4,20 @@ import "leaflet/dist/leaflet.css";
 
 export default function LeafletMap() {
   const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<any>(null);
 
   useEffect(() => {
     // We need to ensure L is loaded before using it (Dynamically importing Leaflet)
-    // TODO: Figure out how to just import leaflet once instead of every time this component is reloaded (causing error in console)
     import("leaflet").then((L) => {
       if (!mapRef.current) return;
 
+      // Check if the map instance already exists
+      if (mapInstanceRef.current) {
+        mapInstanceRef.current.invalidateSize();
+        return;
+      }
       const map = L.map("map").setView([37.9066, -122.0614], 8);
+      mapInstanceRef.current = map;
 
       L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
         maxZoom: 19,
@@ -52,6 +58,7 @@ export default function LeafletMap() {
 
       return () => {
         map.remove();
+        mapInstanceRef.current = null;
       };
     });
   }, []);

--- a/src/components/home/LeafLetMap.tsx
+++ b/src/components/home/LeafLetMap.tsx
@@ -4,7 +4,7 @@ import "leaflet/dist/leaflet.css";
 
 export default function LeafletMap() {
   const mapRef = useRef<HTMLDivElement>(null);
-  const mapInstanceRef = useRef<any>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
 
   useEffect(() => {
     // We need to ensure L is loaded before using it (Dynamically importing Leaflet)

--- a/src/components/home/ReviewCarousel.tsx
+++ b/src/components/home/ReviewCarousel.tsx
@@ -54,7 +54,10 @@ const ReviewCarousel = () => {
   if (!isMounted) return null;
 
   return (
-    <div className="w-full bg-gray-50 relative overflow-hidden">
+    <section
+      id="my-reviews"
+      className="w-full bg-gray-50 relative overflow-hidden"
+    >
       <div className="absolute inset-0 hidden md:block">
         <div className="absolute top-0 left-0 w-96 h-96 bg-blue-900/5 rounded-full -translate-x-1/2 -translate-y-1/2 blur-3xl" />
         <div className="absolute bottom-0 right-0 w-96 h-96 bg-red-500/5 rounded-full translate-x-1/2 translate-y-1/2 blur-3xl" />
@@ -63,10 +66,6 @@ const ReviewCarousel = () => {
 
       <div className="max-w-7xl mx-auto px-4 py-16 md:py-24 relative">
         <div className="text-center mb-12">
-          {/* <h2 className="text-3xl md:text-4xl font-bold text-blue-900 mb-4">
-            What Our Clients Say
-          </h2>
-          <div className="w-24 h-1 bg-red-600 mx-auto"></div> */}
           <HeadlineText
             text="What Our Clients Say"
             colorType="black"
@@ -155,7 +154,7 @@ const ReviewCarousel = () => {
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/home/services/OurServices.tsx
+++ b/src/components/home/services/OurServices.tsx
@@ -6,7 +6,7 @@ import { exteriorServices, interiorServices } from "../utils";
 // Main page component
 const ServicesPage = () => {
   return (
-    <div className="flex flex-col gap-20">
+    <section id="my-services" className="flex flex-col gap-20">
       {/* Benefits section */}
       <BenefitsSection />
 
@@ -27,7 +27,7 @@ const ServicesPage = () => {
         title="Our Exterior Services"
         subtitle="Enhance your property's curb appeal with our expert exterior painting and maintenance services."
       />
-    </div>
+    </section>
   );
 };
 

--- a/src/components/home/services/ServicesButtons.tsx
+++ b/src/components/home/services/ServicesButtons.tsx
@@ -1,8 +1,8 @@
 "use client";
+import { scrollToSection } from "@/components/header/utils";
 import { QuoteButton } from "@/components/shared/QuoteButton";
-// import { QuoteModal } from "@/components/shared/QuoteModal";
+import { useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
-// import { useModal } from "@/hooks/useModal";
 import { ArrowRight } from "lucide-react";
 import { useContext } from "react";
 import { ModalContext } from "@/context/ModalContext";
@@ -29,14 +29,33 @@ export default function ServicesButtons({
   },
   className = "",
 }: ServicesButtonsProps) {
-  // const { isOpen, openModal, closeModal } = useModal();
   const { openModal } = useContext(ModalContext);
 
   // reuse the QuoteButton component to create a button that opens the QuoteModal
-  const href = type === "header" ? "tel:925-594-6142" : "/gallery";
   const linkText = quote?.linkText
     ? quote?.linkText
     : `Explore Our ${type} Work`;
+
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Function to handle button click (redirect to section on home page or another page)
+  function handleHomeClick(
+    e: React.MouseEvent<HTMLButtonElement>,
+    itemId: string
+  ) {
+    e.preventDefault();
+
+    if (pathname === "/our-work") {
+      scrollToSection(itemId);
+    } else {
+      router.push(`/our-work`);
+      // Set timeout to scroll to section after the page has changed
+      setTimeout(() => {
+        scrollToSection(itemId);
+      }, 300);
+    }
+  }
 
   return (
     <div className={`${className} text-center`}>
@@ -48,14 +67,29 @@ export default function ServicesButtons({
 
       {!quote?.justQuote && (
         <div>
-          <Link
-            href={href}
-            className={`text-${quote.colorLink}-500 focus:text-${quote.colorLink}-600 mt-4 hover:text-${quote.colorLink}-600 font-medium inline-flex items-center group transition-colors duration-300 ${quote.underLinkClassName}`}
-            aria-label="Request your free quote"
-          >
-            <span>{linkText}</span>
-            <ArrowRight className="ml-1 h-4 w-4 transition-transform duration-300 group-focus-within:translate-x-1 group-hover:translate-x-1" />
-          </Link>
+          {type !== "header" && (
+            <button
+              className={`text-${quote.colorLink}-500 focus:text-${quote.colorLink}-600 mt-4 hover:text-${quote.colorLink}-600 font-medium inline-flex items-center group transition-colors duration-300 ${quote.underLinkClassName}`}
+              aria-label={linkText}
+              onClick={(e) => {
+                handleHomeClick(e, `${type?.toLowerCase()}-gallery`);
+                console.log("type:", type);
+              }}
+            >
+              <span>{linkText}</span>
+              <ArrowRight className="ml-1 h-4 w-4 transition-transform duration-300 group-focus-within:translate-x-1 group-hover:translate-x-1" />
+            </button>
+          )}
+          {type === "header" && (
+            <Link
+              href="tel:925-594-6142"
+              className={`text-${quote.colorLink}-500 focus:text-${quote.colorLink}-600 mt-4 hover:text-${quote.colorLink}-600 font-medium inline-flex items-center group transition-colors duration-300 ${quote.underLinkClassName}`}
+              aria-label={linkText}
+            >
+              <span>{linkText}</span>
+              <ArrowRight className="ml-1 h-4 w-4 transition-transform duration-300 group-focus-within:translate-x-1 group-hover:translate-x-1" />
+            </Link>
+          )}
         </div>
       )}
     </div>

--- a/src/components/home/services/ServicesSection.tsx
+++ b/src/components/home/services/ServicesSection.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Link from "next/link";
 import ServicesButtons from "./ServicesButtons";
 import { Card } from "@/components/ui/card";
 import Image from "next/image";
@@ -18,6 +19,7 @@ export const ServicesSection = ({
   title,
   subtitle,
 }: ServicesSectionProps) => {
+  // TODO: Fix navigation to gallery via the service card
   const handleServiceClick = (title: string) => {
     console.log(`Navigating to gallery/${title}`);
   };
@@ -43,41 +45,43 @@ export const ServicesSection = ({
               key={index}
               className="transform transition-all duration-300 focus-within::-translate-y-2 focus-within::shadow-xl hover:-translate-y-2 hover:shadow-xl rounded-3xl"
             >
-              <Card
-                className="flex flex-col h-full cursor-pointer overflow-hidden group"
-                onClick={() => handleServiceClick(service.title)}
-                tabIndex={0}
-                role="button"
-                aria-label={`View ${service.title} gallery`}
-                onKeyPress={(e) =>
-                  e.key === "Enter" && handleServiceClick(service.title)
-                }
-              >
-                {/* Fixed height container for image */}
-                <div className="relative h-60 w-full overflow-hidden bg-gray-100">
-                  {service.image ? (
-                    <Image
-                      src={service.image}
-                      alt={`${service.title} service`}
-                      fill
-                      className="w-full h-full object-cover transition-transform duration-500 group-focus:scale-110 group-hover:scale-110"
-                    />
-                  ) : (
-                    <div className="w-full h-full flex items-center justify-center text-gray-400">
-                      No image available
-                    </div>
-                  )}
-                </div>
-                {/* Flex-grow container for text content */}
-                <div className="flex flex-col flex-grow p-6 transition-colors duration-300 group-focus:bg-gray-50 group-hover:bg-gray-50">
-                  <h3 className="text-xl font-semibold mb-3 transition-colors duration-300 group-focus:text-orange-500 group-hover:text-orange-500">
-                    {service.title}
-                  </h3>
-                  <p className="text-gray-600 flex-grow">
-                    {service.description}
-                  </p>
-                </div>
-              </Card>
+              <Link href={`/our-work`}>
+                <Card
+                  className="flex flex-col h-full cursor-pointer overflow-hidden group"
+                  onClick={() => handleServiceClick(service.title)}
+                  tabIndex={0}
+                  role="button"
+                  aria-label={`View ${service.title} gallery`}
+                  onKeyDown={(e) =>
+                    e.key === "Enter" && handleServiceClick(service.title)
+                  }
+                >
+                  {/* Fixed height container for image */}
+                  <div className="relative h-60 w-full overflow-hidden bg-gray-100">
+                    {service.image ? (
+                      <Image
+                        src={service.image}
+                        alt={`${service.title} service`}
+                        fill
+                        className="w-full h-full object-cover transition-transform duration-500 group-focus:scale-110 group-hover:scale-110"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-gray-400">
+                        No image available
+                      </div>
+                    )}
+                  </div>
+                  {/* Flex-grow container for text content */}
+                  <div className="flex flex-col flex-grow p-6 transition-colors duration-300 group-focus:bg-gray-50 group-hover:bg-gray-50">
+                    <h3 className="text-xl font-semibold mb-3 transition-colors duration-300 group-focus:text-orange-500 group-hover:text-orange-500">
+                      {service.title}
+                    </h3>
+                    <p className="text-gray-600 flex-grow">
+                      {service.description}
+                    </p>
+                  </div>
+                </Card>
+              </Link>
             </div>
           ))}
         </div>

--- a/src/components/our-work/Gallery.tsx
+++ b/src/components/our-work/Gallery.tsx
@@ -13,7 +13,6 @@ interface GalleryProps {
 
 const IMAGES_PER_PAGE = 8;
 
-// TODO: Focus user on the lightbox when it opens (trap focus)
 const Gallery = ({ category, imageProps }: GalleryProps) => {
   const [images, setImages] = useState<GalleryImage[]>([]);
   const [loading, setLoading] = useState(true);
@@ -35,6 +34,7 @@ const Gallery = ({ category, imageProps }: GalleryProps) => {
   const handleImageClick = (image: GalleryImage) => {
     setSelectedImage(image);
   };
+
   const loadMore = () => {
     setLoading(true);
     // Simulate loading delay for better UX
@@ -70,6 +70,7 @@ const Gallery = ({ category, imageProps }: GalleryProps) => {
       className="w-full max-w-7xl mx-auto px-4"
       role="region"
       aria-label="Image gallery"
+      id={`${category.toLowerCase()}-gallery`}
     >
       {/* Gallery Header */}
       <GalleryHeader category={category} imageCount={images.length} />
@@ -94,7 +95,7 @@ const Gallery = ({ category, imageProps }: GalleryProps) => {
       )}
 
       {/* Reset Button */}
-      {loadedImages === images.length && (
+      {loadedImages === images.length && category === "Interior" && (
         <LoadMoreResetButton
           onClick={loadLess}
           loading={loading}
@@ -104,7 +105,7 @@ const Gallery = ({ category, imageProps }: GalleryProps) => {
       )}
 
       {/* Lightbox Modal */}
-      {selectedImage && (
+      {selectedImage && category === "Interior" && (
         <LightboxModal
           selectedImage={selectedImage}
           setSelectedImage={setSelectedImage}

--- a/src/components/our-work/GalleryHeader.tsx
+++ b/src/components/our-work/GalleryHeader.tsx
@@ -15,7 +15,7 @@ export default function GalleryHeader({
           <h2 className="text-4xl sm:text-5xl font-bold mb-4 text-transparent bg-clip-text bg-gradient-to-r from-red-600 to-red-400">
             {category}
           </h2>
-          <div className="w-full h-1 bg-gradient-to-r from-red-500 to-red-400 mx-auto mb-6" />
+          <div className="w-[40%] h-1 bg-gradient-to-r from-red-500 to-red-400 mx-auto mb-6" />
         </div>
         <p className="text-gray-600 text-lg max-w-2xl mx-auto">
           Discover our collection of stunning {category.toLowerCase()} projects

--- a/src/components/shared/Footer.tsx
+++ b/src/components/shared/Footer.tsx
@@ -15,6 +15,7 @@ const Footer = () => {
             colorType="white"
             lineColor="red-600"
             headingType="h2"
+            footer={true}
           />
 
           <div className="space-y-4">

--- a/src/components/shared/HeadlineText.tsx
+++ b/src/components/shared/HeadlineText.tsx
@@ -4,6 +4,7 @@ interface HeadlineTextProps {
   headingType: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   className?: string;
   lineColor?: string;
+  footer?: boolean;
 }
 
 export default function HeadlineText({
@@ -12,21 +13,30 @@ export default function HeadlineText({
   headingType,
   className = "",
   lineColor = "orange-500",
+  footer = false,
 }: HeadlineTextProps) {
   const HeadingTag = headingType;
 
   // const textColorClass = colorType === "black" ? "text-gray-900" : "text-white";
 
   return (
-    <div className="relative inline-block">
+    <div className="relative inline-block text-center">
       <HeadingTag
         className={`text-${colorType} ${className} font-bold text-center text-4xl mb-2`}
       >
         {text}
       </HeadingTag>
-      <div
-        className={`absolute -bottom-1 left-0 w-full h-[3px] bg-${lineColor}`}
-      />
+      {!footer && (
+        <div
+          className={`absolute left-1/2 transform -translate-x-1/2 -bottom-1 mx-auto w-[40%] h-[3px] bg-${lineColor}`}
+        />
+      )}
+      {footer && (
+        <div
+          // className={`absolute left-0  transform -translate-x-1/2 -bottom-1 mx-auto w-[40%] h-[3px] bg-${lineColor}`}
+          className={`absolute -bottom-1 left-0 w-full h-[3px] bg-${lineColor}`}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/shared/Landing.tsx
+++ b/src/components/shared/Landing.tsx
@@ -6,9 +6,11 @@ import ServicesButtons from "../home/services/ServicesButtons";
 export default function Landing({
   backgroundPath,
   landingText,
+  headlineText = "Rivas Pro Painting Inc.",
 }: {
   backgroundPath: string;
   landingText: string;
+  headlineText?: string;
 }) {
   return (
     <section
@@ -25,7 +27,7 @@ export default function Landing({
           <div className="flex flex-col items-center">
             {/* <div className="w-20 h-1 bg-orange-500 mb-6" /> */}
             <HeadlineText
-              text="Rivas Pro Painting Inc."
+              text={headlineText}
               colorType="white"
               lineColor="red-600"
               headingType="h1"

--- a/src/components/shared/Landing.tsx
+++ b/src/components/shared/Landing.tsx
@@ -5,8 +5,10 @@ import ServicesButtons from "../home/services/ServicesButtons";
 
 export default function Landing({
   backgroundPath,
+  landingText,
 }: {
   backgroundPath: string;
+  landingText: string;
 }) {
   return (
     <section
@@ -33,7 +35,7 @@ export default function Landing({
 
           <div className="relative">
             <h2 className="relative text-xl md:text-2xl font-light tracking-wide max-w-2xl text-center leading-relaxed">
-              Transforming Homes & Businesses Throughout the Bay Area
+              {landingText}
             </h2>
           </div>
 


### PR DESCRIPTION
- made sure backend GitHub action was only triggered when changes to the backend directory were made.
- fixed header navigation
- Broke gallery components down to smaller ones to take advantage of SSR.
- fixed errors from initializing the map every time the Leaflet component was mounted.
- changed the underline for headline sections from spanning the whole text width to just 40% of the width and centering it for a smoother UI.
- made HeadlineText have customizable text. It was previously hard-coded to the company name.